### PR TITLE
feat: add user management commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -233,6 +233,9 @@ async def _setup_bot_commands(application: Application):
         BotCommand("url", "为已存在的数据源导入指定集数"),
         BotCommand("refresh", "刷新数据源"),
         BotCommand("tokens", "管理API令牌"),
+        BotCommand("adduser", "添加用户"),
+        BotCommand("deleteuser", "删除用户"),
+        BotCommand("listuser", "列出用户"),
         BotCommand("help", "查看帮助信息"),
         BotCommand("cancel", "取消当前操作")
     ]
@@ -473,7 +476,14 @@ def _setup_handlers(application, handlers_module, callback_module):
     token_management_handler = create_token_management_handler()
     application.add_handler(token_management_handler)
     current_handlers["token_management_handler"] = token_management_handler
-    
+
+    # 导入并注册用户管理处理器
+    from handlers.user_management import create_user_management_handlers
+    user_management_handlers = create_user_management_handlers()
+    for name, handler in user_management_handlers:
+        application.add_handler(handler)
+        current_handlers[name] = handler
+
     # 导入并注册refresh处理器
     from handlers.refresh_sources import create_refresh_handler
     refresh_handler = create_refresh_handler()

--- a/handlers/general.py
+++ b/handlers/general.py
@@ -22,6 +22,11 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 【🔑 Token管理】
 /tokens - 管理API访问令牌
 
+【👥 用户管理】
+/addUser <用户ID> - 添加用户
+/deleteUser <用户ID> - 删除用户
+/listUser - 查看用户列表
+
 【其他】
 /help  - 查看帮助信息
 /cancel - 取消当前操作
@@ -49,6 +54,9 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 /url - 为已存在的数据源导入指定集数
 /refresh - 刷新数据源
 /tokens - 管理API访问令牌
+/addUser <用户ID> - 添加用户
+/deleteUser <用户ID> - 删除用户
+/listUser - 查看用户列表
 
 【其他】
 /help  - 查看帮助信息
@@ -95,6 +103,11 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 • /tokens - 管理API访问令牌
   查看、创建、删除访问令牌
 
+【👥 用户管理】
+• /addUser <用户ID> - 添加用户
+• /deleteUser <用户ID> - 删除用户
+• /listUser - 查看用户列表
+
 【📋 其他指令】
 • /help - 显示此帮助信息
 • /cancel - 取消当前操作
@@ -125,6 +138,10 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 • /tokens - 管理API访问令牌
   查看、创建、删除访问令牌
+
+• /addUser <用户ID> - 添加用户
+• /deleteUser <用户ID> - 删除用户
+• /listUser - 查看用户列表
 
 【📋 其他指令】
 • /help - 显示此帮助信息

--- a/handlers/user_management.py
+++ b/handlers/user_management.py
@@ -1,0 +1,78 @@
+import os
+import logging
+from pathlib import Path
+from telegram import Update
+from telegram.ext import ContextTypes, CommandHandler
+from utils.permission import check_admin_permission
+from config import config
+from dotenv import set_key, find_dotenv
+
+logger = logging.getLogger(__name__)
+
+
+def _save_user_ids():
+    """Persist user ID lists to environment and .env file."""
+    env_path = find_dotenv()
+    if not env_path:
+        env_path = '.env'
+    env_path = Path(env_path)
+    allowed_str = ",".join(str(uid) for uid in config.telegram.allowed_user_ids)
+    admin_str = ",".join(str(uid) for uid in config.telegram.admin_user_ids)
+    set_key(str(env_path), "ALLOWED_USER_IDS", allowed_str)
+    set_key(str(env_path), "ADMIN_USER_IDS", admin_str)
+    os.environ["ALLOWED_USER_IDS"] = allowed_str
+    os.environ["ADMIN_USER_IDS"] = admin_str
+
+
+@check_admin_permission
+async def add_user(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    if not context.args:
+        await update.message.reply_text("用法: /addUser <用户ID>")
+        return
+    try:
+        user_id = int(context.args[0])
+    except ValueError:
+        await update.message.reply_text("用户ID必须为数字")
+        return
+    if user_id in config.telegram.allowed_user_ids:
+        await update.message.reply_text("用户已存在")
+        return
+    config.telegram.allowed_user_ids.append(user_id)
+    _save_user_ids()
+    await update.message.reply_text(f"✅ 已添加用户 {user_id}")
+
+
+@check_admin_permission
+async def delete_user(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    if not context.args:
+        await update.message.reply_text("用法: /deleteUser <用户ID>")
+        return
+    try:
+        user_id = int(context.args[0])
+    except ValueError:
+        await update.message.reply_text("用户ID必须为数字")
+        return
+    if user_id not in config.telegram.allowed_user_ids:
+        await update.message.reply_text("用户不存在")
+        return
+    config.telegram.allowed_user_ids = [uid for uid in config.telegram.allowed_user_ids if uid != user_id]
+    if user_id in config.telegram.admin_user_ids:
+        config.telegram.admin_user_ids = [uid for uid in config.telegram.admin_user_ids if uid != user_id]
+    _save_user_ids()
+    await update.message.reply_text(f"✅ 已删除用户 {user_id}")
+
+
+@check_admin_permission
+async def list_user(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    allowed = ", ".join(str(uid) for uid in config.telegram.allowed_user_ids) or "无"
+    admins = ", ".join(str(uid) for uid in config.telegram.admin_user_ids) or "无"
+    message = f"📋 允许用户: {allowed}\n👮 管理员: {admins}"
+    await update.message.reply_text(message)
+
+
+def create_user_management_handlers():
+    return [
+        ("add_user_handler", CommandHandler(["addUser", "adduser"], add_user)),
+        ("delete_user_handler", CommandHandler(["deleteUser", "deleteuser"], delete_user)),
+        ("list_user_handler", CommandHandler(["listUser", "listuser"], list_user)),
+    ]


### PR DESCRIPTION
## Summary
- allow admins to dynamically add, delete and list users
- document new user management commands in help and start messages
- register new bot commands for user management

## Testing
- `python -m py_compile bot.py handlers/general.py handlers/user_management.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd9ce1e894832488e39d4e5024c3af