### PR TITLE
feat: add admin quota query command

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ python bot.py
 - ✅ Token管理 (`/tokens`)
 - ✅ 用户管理 (`/addUser`, `/deleteUser`, `/listUser`)
 - ✅ 帮助和取消操作 (`/help`, `/cancel`)
+- ✅ 查询全局配额 (`/quota`，需控制 Token)
 
 ### 普通用户权限
 普通用户（在 `ALLOWED_USER_IDS` 中配置但不在 `ADMIN_USER_IDS` 中）仅有基础功能权限：
@@ -121,6 +122,7 @@ python bot.py
 - ❌ 刷新数据源 (`/refresh`) - 需要管理员权限
 - ❌ Token管理 (`/tokens`) - 需要管理员权限
 - ❌ 用户管理 (`/addUser`, `/deleteUser`, `/listUser`) - 需要管理员权限
+- ❌ 查询全局配额 (`/quota`) - 需要管理员权限
 
 > 💡 **提示**: 普通用户可以看到所有功能选项，但点击管理员专用功能时会收到权限不足的提示。
 
@@ -139,6 +141,7 @@ python bot.py
 - 🌐 代理支持
 - 📊 详细日志记录
 - 🔥 热重载开发支持
+- 🔢 全局配额查询
 
 ## 许可证
 

--- a/bot.py
+++ b/bot.py
@@ -233,6 +233,7 @@ async def _setup_bot_commands(application: Application):
         BotCommand("url", "为已存在的数据源导入指定集数"),
         BotCommand("refresh", "刷新数据源"),
         BotCommand("tokens", "管理API令牌"),
+        BotCommand("quota", "查看全局配额"),
         BotCommand("adduser", "添加用户"),
         BotCommand("deleteuser", "删除用户"),
         BotCommand("listuser", "列出用户"),
@@ -483,6 +484,12 @@ def _setup_handlers(application, handlers_module, callback_module):
     for name, handler in user_management_handlers:
         application.add_handler(handler)
         current_handlers[name] = handler
+
+    # 导入并注册配额查询处理器
+    from handlers.quota import create_quota_handler
+    quota_handler = create_quota_handler()
+    application.add_handler(quota_handler)
+    current_handlers["quota_handler"] = quota_handler
 
     # 导入并注册refresh处理器
     from handlers.refresh_sources import create_refresh_handler

--- a/handlers/general.py
+++ b/handlers/general.py
@@ -22,6 +22,9 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 【🔑 Token管理】
 /tokens - 管理API访问令牌
 
+【📊 配额查询】
+/quota - 查询全局配额
+
 【👥 用户管理】
 /addUser <用户ID> - 添加用户
 /deleteUser <用户ID> - 删除用户
@@ -38,8 +41,8 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
         keyboard = [
             [KeyboardButton("/search"), KeyboardButton("/auto")],
             [KeyboardButton("/url"), KeyboardButton("/refresh")],
-            [KeyboardButton("/tokens"), KeyboardButton("/help")],
-            [KeyboardButton("/cancel")]
+            [KeyboardButton("/tokens"), KeyboardButton("/quota")],
+            [KeyboardButton("/help"), KeyboardButton("/cancel")]
         ]
     else:
         welcome_msg = """
@@ -54,6 +57,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 /url - 为已存在的数据源导入指定集数
 /refresh - 刷新数据源
 /tokens - 管理API访问令牌
+/quota - 查询全局配额
 /addUser <用户ID> - 添加用户
 /deleteUser <用户ID> - 删除用户
 /listUser - 查看用户列表
@@ -69,8 +73,8 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
         keyboard = [
             [KeyboardButton("/search"), KeyboardButton("/auto")],
             [KeyboardButton("/url"), KeyboardButton("/refresh")],
-            [KeyboardButton("/tokens"), KeyboardButton("/help")],
-            [KeyboardButton("/cancel")]
+            [KeyboardButton("/tokens"), KeyboardButton("/quota")],
+            [KeyboardButton("/help"), KeyboardButton("/cancel")]
         ]
     
     # 移除自定义键盘，只保留命令菜单
@@ -102,6 +106,9 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 【🔑 Token管理】
 • /tokens - 管理API访问令牌
   查看、创建、删除访问令牌
+
+【📊 配额查询】
+• /quota - 查询剩余全局配额和总配额
 
 【👥 用户管理】
 • /addUser <用户ID> - 添加用户
@@ -138,6 +145,8 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 • /tokens - 管理API访问令牌
   查看、创建、删除访问令牌
+
+• /quota - 查询全局配额
 
 • /addUser <用户ID> - 添加用户
 • /deleteUser <用户ID> - 删除用户

--- a/handlers/quota.py
+++ b/handlers/quota.py
@@ -1,0 +1,54 @@
+import logging
+from telegram import Update
+from telegram.ext import ContextTypes, CommandHandler
+from utils.api import call_danmaku_api
+from utils.permission import check_admin_permission
+from config import ConfigManager
+
+logger = logging.getLogger(__name__)
+
+@check_admin_permission
+async def check_quota(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """查询并显示全局配额信息"""
+    try:
+        config = ConfigManager()
+        response = call_danmaku_api(
+            'GET',
+            '/rate-limit/status',
+            params={'token': config.danmaku_api.api_key}
+        )
+        if not response or not response.get('success'):
+            error_msg = response.get('error') or response.get('message', '未知错误') if response else '未知错误'
+            await update.message.reply_text(f"❌ 获取配额信息失败: {error_msg}")
+            return
+
+        data = response.get('data', {}) or {}
+        if isinstance(data, dict):
+            global_limit = data.get('globalLimit')
+            request_count = data.get('globalRequestCount', 0)
+            if isinstance(global_limit, (int, float)):
+                total = global_limit
+                remaining = max(global_limit - request_count, 0)
+            elif str(global_limit).lower() in ['∞', 'inf', 'infinite', 'infinity'] or global_limit is None:
+                total = remaining = '∞'
+            else:
+                total = remaining = None
+        else:
+            total = remaining = None
+
+        if total is None and remaining is None:
+            await update.message.reply_text("❌ API未返回配额信息")
+            return
+
+        total_display = total if total is not None else '未知'
+        remaining_display = remaining if remaining is not None else '未知'
+        await update.message.reply_text(
+            f"📊 全局配额信息：\n剩余：{remaining_display}\n总配额：{total_display}"
+        )
+    except Exception as e:
+        logger.error(f"查询配额信息失败: {e}")
+        await update.message.reply_text("❌ 查询配额信息时发生错误")
+
+def create_quota_handler():
+    """创建查询配额命令处理器"""
+    return CommandHandler('quota', check_quota)


### PR DESCRIPTION
## Summary
- add `/quota` admin command to check remaining and total global quota via `/api/control/rate-limit/status`
- register command and update start/help messages
- document the quota command and token requirement in README

## Testing
- `python -m pytest`
- `flake8` *(fails: see log for style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb1f5b030832480958c2995962e23