### PR TITLE
feat: add numeric task status, persist users, allow group commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ python bot.py
 - ✅ 用户管理 (`/addUser`, `/deleteUser`, `/listUser`)
 - ✅ 帮助和取消操作 (`/help`, `/cancel`)
 - ✅ 查询全局配额 (`/quota`，需控制 Token)
-- ✅ 查询任务状态 (`/tasks`)
+- ✅ 查询任务状态 (`/tasks [状态码]`)
 
 
 ### 普通用户权限
@@ -121,7 +121,7 @@ python bot.py
 - ✅ 自动导入功能 (`/auto`)
 - ✅ 帮助和取消操作 (`/help`, `/cancel`)
 - ✅ 查询全局配额 (`/quota`)
-- ✅ 查询任务状态 (`/tasks`)
+- ✅ 查询任务状态 (`/tasks [状态码]`)
 - ❌ URL链接导入 (`/url`) - 需要管理员权限
 - ❌ 刷新数据源 (`/refresh`) - 需要管理员权限
 - ❌ Token管理 (`/tokens`) - 需要管理员权限
@@ -142,7 +142,7 @@ python bot.py
 - 🎭 豆瓣链接解析支持（自动识别豆瓣链接并获取媒体信息）
 - 🌟 IMDB链接解析支持（自动识别IMDB链接并获取媒体信息）
 - 🎯 Bangumi(BGM)链接解析支持（自动识别BGM链接并获取媒体信息，支持API和爬虫双模式）
-- 📋 任务状态查询（`/tasks`，支持按状态过滤：all/in_progress/completed）
+- 📋 任务状态查询（`/tasks`，支持按状态码过滤：0=all,1=in_progress,2=completed）
 - 🌐 代理支持
 - 📊 详细日志记录
 - 🔥 热重载开发支持

--- a/bot.py
+++ b/bot.py
@@ -297,12 +297,17 @@ def _setup_handlers(application, handlers_module, callback_module):
 
         if message.entities:
             for entity in message.entities:
+                if entity.type == "bot_command":
+                    return
                 if entity.type == "mention":
                     mention = text[entity.offset: entity.offset + entity.length]
                     if mention.lower() == f"@{bot_username.lower()}":
                         return
                 elif entity.type == "text_mention" and entity.user and entity.user.id == context.bot.id:
                     return
+
+        if text.startswith("/"):
+            return
 
         if f"@{bot_username.lower()}" in text.lower():
             return

--- a/data/users.json
+++ b/data/users.json
@@ -1,0 +1,1 @@
+{"allowed_user_ids": [], "admin_user_ids": []}

--- a/handlers/general.py
+++ b/handlers/general.py
@@ -26,7 +26,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 /quota - 查询全局配额
 
 【📋 任务查询】
-/tasks [状态] - 查看任务列表（默认 all）
+/tasks [状态码] - 查看任务列表（0=all,1=in_progress,2=completed；默认0）
 
 【👥 用户管理】
 /addUser <用户ID> - 添加用户
@@ -58,7 +58,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 【📋 任务查询】
-/tasks [状态] - 查看任务列表（默认 all）
+/tasks [状态码] - 查看任务列表（0=all,1=in_progress,2=completed；默认0）
 
 【📊 配额查询】
 /quota - 查询全局配额
@@ -120,7 +120,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 • /quota - 查询剩余全局配额和总配额
 
 【📋 任务查询】
-• /tasks [状态] - 查看任务列表（默认 all）
+• /tasks [状态码] - 查看任务列表（0=all,1=in_progress,2=completed；默认0）
 
 【👥 用户管理】
 • /addUser <用户ID> - 添加用户
@@ -149,7 +149,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
   支持关键词搜索和多平台链接导入
 
 【📋 任务查询】
-• /tasks [状态] - 查看任务列表（默认 all）
+• /tasks [状态码] - 查看任务列表（0=all,1=in_progress,2=completed；默认0）
 
 【📊 配额查询】
 • /quota - 查询全局配额

--- a/handlers/tasks.py
+++ b/handlers/tasks.py
@@ -8,13 +8,21 @@ logger = logging.getLogger(__name__)
 
 @check_user_permission
 async def list_tasks(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """查询任务列表，可按状态过滤"""
-    # 解析状态参数，默认 all
-    status = "all"
+    """查询任务列表，可按状态码过滤 (0=all,1=in_progress,2=completed)"""
+    # 解析状态参数，默认 0（全部）
+    status = "0"
     if context.args:
         arg = context.args[0].lower()
-        if arg in {"all", "in_progress", "completed"}:
-            status = arg
+        status_map = {
+            "0": "0",
+            "1": "1",
+            "2": "2",
+            "all": "0",
+            "in_progress": "1",
+            "completed": "2",
+        }
+        if arg in status_map:
+            status = status_map[arg]
     try:
         response = call_danmaku_api("GET", "/tasks", params={"status": status})
         if not response or not response.get("success"):

--- a/handlers/user_management.py
+++ b/handlers/user_management.py
@@ -1,27 +1,23 @@
-import os
+import json
 import logging
-from pathlib import Path
 from telegram import Update
 from telegram.ext import ContextTypes, CommandHandler
 from utils.permission import check_admin_permission
 from config import config
-from dotenv import set_key, find_dotenv
 
 logger = logging.getLogger(__name__)
 
 
 def _save_user_ids():
-    """Persist user ID lists to environment and .env file."""
-    env_path = find_dotenv()
-    if not env_path:
-        env_path = '.env'
-    env_path = Path(env_path)
-    allowed_str = ",".join(str(uid) for uid in config.telegram.allowed_user_ids)
-    admin_str = ",".join(str(uid) for uid in config.telegram.admin_user_ids)
-    set_key(str(env_path), "ALLOWED_USER_IDS", allowed_str)
-    set_key(str(env_path), "ADMIN_USER_IDS", admin_str)
-    os.environ["ALLOWED_USER_IDS"] = allowed_str
-    os.environ["ADMIN_USER_IDS"] = admin_str
+    """Persist user ID lists to JSON file."""
+    path = config.user_config_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "allowed_user_ids": config.telegram.allowed_user_ids,
+        "admin_user_ids": config.telegram.admin_user_ids,
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
 
 
 @check_admin_permission


### PR DESCRIPTION
## Summary
- support numeric task status codes `0`, `1`, `2` in `/tasks`
- document status code mapping in help text and README
- persist admin and allowed user IDs to `data/users.json`
- allow group commands without mentioning the bot

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bdc7cd707c832489389b4cec931d0a